### PR TITLE
lmao-bot v1.3.2

### DIFF
--- a/lmao-bot.html
+++ b/lmao-bot.html
@@ -45,7 +45,7 @@
           font-family: Tahoma, Verdana, Sans-Serif;
           font-size: 20px;
       }
-      h2 {
+      h2, h3 {
       	text-align: center;
       }
       a {
@@ -114,11 +114,11 @@
       <td>Sends the bot's latency (ping).</td>
     </tr>
     <tr>
-      <td>lmao prefix <span class="noweight">&quot;new_prefix&quot;</span></td>
+      <td>lmao prefix <span class="noweight">new_prefix</span></td>
       <td>Changes the bot's command prefix to <code>new_prefix</code>. Available to server admins and lmao admins only. Default is "lmao".</td>
     </tr>
     <tr>
-      <td>lmao about</td>
+      <td>lmao info</td>
       <td>Gives a brief description about the bot, including an invite to the support server.</td>
     </tr>
     <tr>
@@ -236,6 +236,10 @@
     <tr>
       <td>lmao vol <span class="noweight">percent</span></td>
       <td>Does the same thing as <code>lmao volume</code>.</td>
+    </tr>
+    <tr>
+      <td>lmao loop</td>
+      <td>Play the current queue on loop.</td>
     </tr>
     <tr>
       <td>lmao queue</td>
@@ -398,6 +402,14 @@
       <th>Description</th>
     </tr>
     <tr>
+      <td>lmao avatar <span class="noweight">mention</span></td>
+      <td>Sends an image of the mentioned user's avatar.</td>
+    </tr>
+    <tr>
+      <td>lmao someone <span class="noweight">message</span></td>
+      <td>Pings a random person in the server with your message.</td>
+    </tr>
+    <tr>
       <td>lmao urban <span class="noweight">term</span></td>
       <td>Provides the definition for <code>term</code> on Urban Dictionary. Only works in NSFW channels.</td>
     </tr>
@@ -532,14 +544,20 @@
       <td>Edits a custom filter to say something else.</td>
     </tr>
     <tr>
-      <td>lmao filter flags</td>
-      <td>Change the configuration (flags) of a filter. Flags include <code>nomention</code> and <code>casesensitive</code>.</td>
+      <td>lmao filter options</td>
+      <td>Change the options (flags) of a filter. Flags include <code>nomention</code>, <code>casesensitive</code>, <code>wholeword</code>, and <code>chance</code>.</td>
     </tr>
     <tr>
       <td>lmao filter remove</td>
       <td>Removes a custom filter.</td>
     </tr>
   </table>
+
+  <hr />
+
+  <h3>Taco-bot</h3>
+
+  <p>Want a taco-themed economy and utility bot that can do it all? <a href="https://discordbots.org/bot/511400985596395521">Look no further than Taco-bot</a>, lmao-bot's official partner!</p>
 
   </body>
 </html>

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -6,11 +6,12 @@ import json
 import math
 import asyncio
 from utils import lbvars, usage, perms, lbutil
+from modules import music
 import time
 import pandas as pd
 
 class Dev:
-    "Developer Commands"
+    """Developer Commands"""
     __slots__ = ('bot')
 
     def __init__(self, bot):
@@ -104,8 +105,38 @@ class Dev:
         usage.update(ctx)
         return ctx.command.name
 
-    @commands.command(name="showusage", hidden=True)
-    async def cmd_show_usage(self, ctx, bars=15, width=6.4, height=4.8):
+    # @commands.command(name="showusage", hidden=True)
+    # async def cmd_show_usage(self, ctx, command="", width=6.4, height=4.8):
+    #     with io.open("data/cmd_usage.json") as f:
+    #         usage_data = json.load(f).get(command)
+    #     if usage_data is None:
+    #         await ctx.send(f"Command {command} not found.")
+    #         usage.update(ctx)
+    #         return ctx.command.name
+    #
+
+    @commands.command(name="disconnectguild", hidden=True)
+    async def cmd_disconnect_guild(self, ctx, id: int=0, *, message: str=""):
+        music_cog = self.bot.get_cog("Music")
+        player = music_cog.players.get(id)
+        if player is None:
+            await ctx.send(f"Music player for {id} does not exist.")
+            usage.update(ctx)
+            return ctx.command.name
+        channel = player._channel
+        title = "❌ Disconnecting from the voice channel"
+        desc = "lmao-bot is being manually disconnected from your voice channel.\n\nSorry for the inconvenience."
+        e = discord.Embed(title=title, description=desc)
+        if message.strip() != "":
+            e.add_field(name="Reason", value=message.strip())
+        await channel.send(embed=e)
+        music_cog.players.pop(id, 0)
+        await self.bot.get_guild(id).voice_client.disconnect()
+        usage.update(ctx)
+        return ctx.command.name
+
+    @commands.command(name="showallusage", hidden=True)
+    async def cmd_show_all_usage(self, ctx, bars=15, width=6.4, height=4.8):
         with io.open("data/cmd_usage.json") as f:
             usage_data = json.load(f)
         commands = []

--- a/modules/mod.py
+++ b/modules/mod.py
@@ -67,6 +67,19 @@ class Mod:
         usage.update(ctx)
         return ctx.command.name
 
+    # @commands.command(name="disable")
+    # async def cmd_disable(self, ctx, *, arg=""):
+    #     cmd = arg.strip()
+    #     if cmd == "":
+    #         #TODO: Instead of error message, prompt the user
+    #         await ctx.send(f"To disable a command, use `{ctx.prefix}disable command_name`, where `command_name` is the name of the command you want to disable. e.g. `{ctx.prefix}disable someone`\n\n" \
+    #             "Not that not all commands can be disabled and that only lmao administrators and server administrators can enable/disable commands.")
+    #         usage.update(ctx)
+    #         return ctx.command.name
+    #     #disable here
+    #     usage.update(ctx)
+    #     return ctx.command.name
+
     @commands.command(name="purge", aliases=["clear", "clean", "prune"])
     async def cmd_purge(self, ctx, *, arg=""):  # Allows the deletion of messages
         if perms.get_perms(ctx.message).manage_messages or perms.is_lmao_admin(ctx.message):

--- a/modules/utility.py
+++ b/modules/utility.py
@@ -98,6 +98,8 @@ class Utility:
     async def cmd_someone(self, ctx, *, arg=""):
         someone = rng.choice(ctx.guild.members)
         await ctx.send(perms.clean_everyone(ctx, f"{someone.mention} {arg}"))
+        usage.update(ctx)
+        return ctx.command.name
 
     @commands.command(name="avatar", aliases=["pfp", "image", "profilepic", "profilepicture"])
     async def cmd_avatar(self, ctx):

--- a/utils/lbvars.py
+++ b/utils/lbvars.py
@@ -44,6 +44,12 @@ def export_settings(guild_id):
         new_admins_data = json.dumps(admins_data, indent=4)
         with io.open("data/admins.json", "w+", encoding="utf-8") as fo:
             fo.write(new_admins_data)
+    # with io.open("data/disabled.json") as f:
+    #     disabled_data = json.load(f)
+    #     disabled_data[guild_id] = get_lmao_admin_list(guild_id)
+    #     new_disabled_data = json.dumps(disabled_data, indent=4)
+    #     with io.open("data/disabled.json", "w+", encoding="utf-8") as fo:
+    #         fo.write(new_disabled_data)
     with io.open("data/filters.json") as f:
         filters_data = json.load(f)
         filters_data[guild_id] = get_filter_list(guild_id)
@@ -58,6 +64,11 @@ def export_settings(guild_id):
             fo.write(new_customs_data)
 def update_settings(guild_id, guild_settings):
     settings[guild_id] = guild_settings
+def init_settings(guild_id):
+    if guild_id not in settings:
+        settings[guild_id] = GuildSettings(guild_id)
+        return True
+    return False
 
 def set_no_command_invoked(invoked):
     global no_command_invoked
@@ -77,15 +88,19 @@ class GuildSettings:
         self.init_prefix()
 
         # List for storing lmao admins
-        self.lmao_admin_list = "[]"
+        self.lmao_admin_list = []
         self.init_lmao_admin_list()
 
+        # List for storing disabled commands
+        # self.disabled_cmd_list = []
+        # self.init_disabled_cmd_list()
+
         # Dictionary for storing custom filters
-        self.filter_list = "{}"
+        self.filter_list = {}
         self.init_filter_list()
 
         # Dictionary for storing custom commands.
-        self.custom_cmd_list = "{}"
+        self.custom_cmd_list = {}
         self.init_custom_cmd_list()
 
         # Chance of ass replacement
@@ -181,6 +196,26 @@ class GuildSettings:
     def get_lmao_admin_list(self):
         return self.lmao_admin_list
 
+    #TODO
+    # def init_disabled_cmd_list(self):
+    #     with io.open("data/admins.json") as f:
+    #         admins_data = json.load(f)
+    #         try:
+    #             self.lmao_admin_list = admins_data[self.guild_id]
+    #         except KeyError:
+    #             self.lmao_admin_list = []
+    # def add_lmao_admin(self, member_id):
+    #     self.lmao_admin_list.append(str(member_id))
+    #     return self.lmao_admin_list
+    # def remove_lmao_admin(self, member_id):
+    #     self.lmao_admin_list = [admin for admin in self.lmao_admin_list[self.guild_id] if admin != str(member_id)]
+    #     return self.lmao_admin_list
+    # def set_lmao_admin_list(self, lmao_admin_list):
+    #     self.lmao_admin_list = lmao_admin_list
+    #     return self.lmao_admin_list
+    # def get_lmao_admin_list(self):
+    #     return self.lmao_admin_list
+
     def init_filter_list(self):
         with io.open("data/filters.json") as f:
             full_filter_list = json.load(f)
@@ -246,6 +281,10 @@ def get_maintenance_time():
 def increment_guild_count():
     global guild_count
     guild_count += 1
+    return guild_count
+def decrement_guild_count():
+    global guild_count
+    guild_count -= 1
     return guild_count
 def reset_guild_count():
     global guild_count


### PR DESCRIPTION
Created conduct.md.

Endless loop glitch with the 1006 websocket error codes *should* be fixed now that the on_ready event was restructured and the update_settings function call was replaced with init_settings, reducing workload on the bot on_ready.

New dev command: disconnectguild. Disconnects a guild's music player via ID with an optional reason.

HTML page updated with most recent commands and now includes a partnership with Taco-bot.

showusage renamed to showallusage in dev.py.

Begun working on some commands (currently commented out): disable (mod.py) and showusage (dev.py).